### PR TITLE
change featureExtractor to pytorch resnet18 model

### DIFF
--- a/src/ransacflow/model/model_orig.py
+++ b/src/ransacflow/model/model_orig.py
@@ -19,98 +19,30 @@ def conv3x3(in_features, out_features, stride=1):
     """3x3 convolution with padding"""
     return nn.Conv2d(in_features, out_features, kernel_size=3, stride=stride, padding=1, bias=False)
 
-def conv1x1(in_features, out_features, stride=1):
-    """1x1 convolution"""
-    return nn.Conv2d(in_features, out_features, kernel_size=1, stride=stride, bias=False)
-    
-class BasicBlock(nn.Module):
-    expansion = 1
-
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
-        super(BasicBlock, self).__init__()
-        self.conv1 = conv3x3(inplanes, planes, stride)
-        self.bn1 = nn.BatchNorm2d(planes, eps=1e-05)
-        self.relu = nn.ReLU(inplace=True)
-        self.conv2 = conv3x3(planes, planes)
-        self.bn2 = nn.BatchNorm2d(planes, eps=1e-05)
-        self.downsample = downsample
-        #self.stride = stride
-
-    def forward(self, x):
-        residual = x
-
-        out = self.conv1(x)
-        out = self.bn1(out)
-        out = self.relu(out)
-
-        out = self.conv2(out)
-        out = self.bn2(out)
-
-        if self.downsample is not None:
-            residual = self.downsample(x)
-
-        out += residual
-        out = self.relu(out)
-
-        return out
-
-
 class FeatureExtractor(nn.Module):
 
     def __init__(self):
         
-        self.inplanes = 64
         super(FeatureExtractor, self).__init__()
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+
+        resnet = models.resnet18(pretrained=True)
+        # change conv1 with kernel size 3
+        resnet.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+
+        # ResNet contains
+        #   conv1 / bn1 / relu / maxpool / layer1-4 / avgpool / fc
+        # we only want till layer3
+        layer_list = ["conv1", "bn1", "relu", "maxpool", "layer1", "layer2", "layer3"]
+        layers = [getattr(resnet, name) for name in layer_list]
+        resnet = nn.Sequential(*layers)
+        self.resnet = resnet                           
                                          
-                                         
-        
-        self.bn1 = nn.BatchNorm2d(64, eps=1e-05)
-        self.relu = nn.ReLU(inplace=True)
-        self.maxpool = nn.Sequential(*[nn.MaxPool2d(kernel_size=2, stride=1), 
-                                        Downsample(filt_size=3, stride=2, channels=64)])
-        self.layer1 = self._make_layer(BasicBlock, 64, 2)
-        self.layer2 = self._make_layer(BasicBlock, 128, 2, stride=2)
-        self.layer3 = self._make_layer(BasicBlock, 256, 2, stride=2)
-        
-        for m in self.modules():
-            if isinstance(m, nn.Conv2d):
-                if(m.in_channels!=m.out_channels or m.out_channels!=m.groups or m.bias is not None):
-                    # don't want to reinitialize downsample layers, code assuming normal conv layers will not have these characteristics
-                    nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
-                else:
-                    print('Not initializing')
-            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
-                nn.init.constant_(m.weight, 1)
-                nn.init.constant_(m.bias, 0)
 
-    # STILL NO IDEA
-    def _make_layer(self, block, planes, num_block, stride=1):
-        downsample = None
-        if stride != 1 or self.inplanes != planes * block.expansion:
-            downsample = [Downsample(filt_size=3, stride=stride, channels=self.inplanes),] if(stride !=1) else []
-            downsample += [conv1x1(self.inplanes, planes * block.expansion, 1), nn.BatchNorm2d(planes * block.expansion)]
-            downsample = nn.Sequential(*downsample)
-
-        layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample))
-        self.inplanes = planes * block.expansion
-        for i in range(1, num_block):
-            layers.append(block(self.inplanes, planes, 1, None))
-
-        return nn.Sequential(*layers)   
-                    
     def forward(self, x):
         
-        x = self.conv1(x)
-        x = self.bn1(x)
-        x = self.relu(x)
-        x = self.maxpool(x)
-        x = self.layer1(x)
-        x = self.layer2(x)
-        x = self.layer3(x) 
+        x = self.resnet(x)
         return x
-
+    
 
 # compare features in square neighborhood
 class CorrNeigh(nn.Module):


### PR DESCRIPTION
Change FeatureExtractor to pytorch resnet18 architecture.
The difference between the source code and resnet18 is at maxpool layer, where source code uses adobe downsample + maxpool2d(stride = 1), while resnet18 uses maxpool2d(stride = 2). The trainable parameters of two architectures are the same. I also ran the Stage 1 training for resnet18 architecture and it looked like the visual result (fine alignment) is similar to the one of the source code.
Based on the similar trained results, I change to resent18 architecture for simplicity. But please feel free to change back to the design of source code. 